### PR TITLE
Add custom titan ready message

### DIFF
--- a/mods/Dinorush.Brute4/mod/scripts/vscripts/TitanFrameworkInitBrute4.nut
+++ b/mods/Dinorush.Brute4/mod/scripts/vscripts/TitanFrameworkInitBrute4.nut
@@ -8,6 +8,7 @@ void function Brute4_UIInit()
 		Brute.BaseSetFile = "titan_stryder_sniper"
 		Brute.BaseName = "northstar"
 		Brute.passiveDisplayNameOverride = "#TITAN_BRUTE4_PASSIVE_TITLE"
+		Brute.titanReadyMessageOverride = "#HUD_BRUTE4_READY"
 		Brute.difficulty = 1
 		Brute.speedStat = 3
 		Brute.damageStat = 3


### PR DESCRIPTION
Replaces the generic "TITAN READY" message from titan framework with the one found in this mod's localization file.

Before:
![1237970_20240907170715_1](https://github.com/user-attachments/assets/cd760a35-2961-4d7f-858c-b27597e822c2)

After:
![1237970_20240907170625_1](https://github.com/user-attachments/assets/4e62d7e2-de07-48f3-8895-58579038a08d)
