### PR TITLE
Multiple weapon fixes

### DIFF
--- a/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
+++ b/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
@@ -18,8 +18,6 @@ var function OnWeaponPrimaryAttack_cluster_payload( entity weapon, WeaponPrimary
 	array<entity> weapons = GetPrimaryWeapons( weaponOwner )
 	entity primaryWeapon = weapons[0]
 
-        int AmmoMax = primaryWeapon.GetWeaponPrimaryClipCountMax()
-
 	if ( !IsValid( primaryWeapon ) )
 		return false
 	else if ( weaponOwner.ContextAction_IsActive() )
@@ -28,8 +26,6 @@ var function OnWeaponPrimaryAttack_cluster_payload( entity weapon, WeaponPrimary
 		return false
 	else if ( primaryWeapon.HasMod( "cluster_payload" ) )
 		return false
-	else if ( primaryWeapon.GetWeaponPrimaryClipCount() >= AmmoMax )
-	    return false
 
 	#if SERVER
 	thread SwapRocketAmmo( weaponOwner, weapon, primaryWeapon )

--- a/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
+++ b/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
@@ -126,11 +126,10 @@ void function ForceRefreshIfNotReloading( entity weapon, entity weaponOwner )
 	WaitFrame()
 	if ( !IsValid( weapon ) || !IsValid( weaponOwner ) || weapon.IsReloading() || weapon != weaponOwner.GetActiveWeapon() )
 		return
-
+	
 	weapon.AddMod( "fast_deploy" )
 	weaponOwner.HolsterWeapon()
 	weaponOwner.DeployWeapon()
 	weapon.RemoveMod( "fast_deploy" )
 }
-
 #endif

--- a/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
+++ b/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
@@ -26,6 +26,8 @@ var function OnWeaponPrimaryAttack_cluster_payload( entity weapon, WeaponPrimary
 		return false
 	else if ( primaryWeapon.HasMod( "cluster_payload" ) )
 		return false
+	else if ( primaryWeapon.GetWeaponPrimaryClipCount() >= 16 ) //GetWeaponPrimaryClipCountMax doesnt work. why??
+	    return false
 
 	#if SERVER
 	thread SwapRocketAmmo( weaponOwner, weapon, primaryWeapon )

--- a/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
+++ b/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
@@ -18,6 +18,8 @@ var function OnWeaponPrimaryAttack_cluster_payload( entity weapon, WeaponPrimary
 	array<entity> weapons = GetPrimaryWeapons( weaponOwner )
 	entity primaryWeapon = weapons[0]
 
+        int AmmoMax = primaryWeapon.GetWeaponPrimaryClipCountMax()
+
 	if ( !IsValid( primaryWeapon ) )
 		return false
 	else if ( weaponOwner.ContextAction_IsActive() )
@@ -26,7 +28,7 @@ var function OnWeaponPrimaryAttack_cluster_payload( entity weapon, WeaponPrimary
 		return false
 	else if ( primaryWeapon.HasMod( "cluster_payload" ) )
 		return false
-	else if ( primaryWeapon.GetWeaponPrimaryClipCount() >= 16 ) //GetWeaponPrimaryClipCountMax doesnt work. why??
+	else if ( primaryWeapon.GetWeaponPrimaryClipCount() >= AmmoMax )
 	    return false
 
 	#if SERVER

--- a/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
+++ b/mods/Dinorush.Brute4/mod/scripts/vscripts/weapons/mp_titanability_cluster_payload.nut
@@ -71,7 +71,6 @@ void function SwapRocketAmmo( entity weaponOwner, entity offhand, entity weapon 
 
 	offhand.AddMod( "no_regen" )
 
-	weapon.SetWeaponPrimaryClipCount( 0 )
 	if ( weapon.IsReloading() )
 	{
 		weapon.AddMod( "fast_deploy" )
@@ -79,6 +78,9 @@ void function SwapRocketAmmo( entity weaponOwner, entity offhand, entity weapon 
 		weaponOwner.DeployWeapon()
 		weapon.RemoveMod( "fast_deploy" )
 	}
+	else
+		thread ForceRefreshIfNotReloading( weapon, weaponOwner )
+	weapon.SetWeaponPrimaryClipCount( 0 )
 
 	OnThreadEnd(
 	function() : ( weaponOwner, weapon, offhand )
@@ -118,4 +120,17 @@ void function SwapRocketAmmo( entity weaponOwner, entity offhand, entity weapon 
 		WaitFrame()
 	}
 }
+
+void function ForceRefreshIfNotReloading( entity weapon, entity weaponOwner )
+{
+	WaitFrame()
+	if ( !IsValid( weapon ) || !IsValid( weaponOwner ) || weapon.IsReloading() || weapon != weaponOwner.GetActiveWeapon() )
+		return
+
+	weapon.AddMod( "fast_deploy" )
+	weaponOwner.HolsterWeapon()
+	weaponOwner.DeployWeapon()
+	weapon.RemoveMod( "fast_deploy" )
+}
+
 #endif

--- a/mods/Dinorush.Brute4/mod/scripts/weapons/mp_titanability_cluster_payload.txt
+++ b/mods/Dinorush.Brute4/mod/scripts/weapons/mp_titanability_cluster_payload.txt
@@ -16,6 +16,8 @@ WeaponData
 	"OnWeaponPrimaryAttack"							"OnWeaponPrimaryAttack_cluster_payload"
 	"OnWeaponNpcPrimaryAttack"						"OnWeaponNpcPrimaryAttack_cluster_payload"
 
+	"sound_weapon_ready"							"HUD_TitanUtilityAbility_replenished_1P"
+
 	"damage_type" 									"none"
 
 	// Sound

--- a/mods/Dinorush.Brute4/mod/scripts/weapons/mp_titancore_barrage_core.txt
+++ b/mods/Dinorush.Brute4/mod/scripts/weapons/mp_titancore_barrage_core.txt
@@ -1,9 +1,9 @@
 WeaponData
 {
-	"printname"										"Barrage Core"
-	"shortprintname"								"#TITANCORE_CLUSTER_SHORT"
-	"description"									"#TITANCORE_CLUSTER_DESC"
-	"longdesc"										"#TITANCORE_CLUSTER_LONGDESC"
+	"printname"										"#TITANCORE_BARRAGE"
+	"shortprintname"								"#TITANCORE_BARRAGE_SHORT"
+	"description"									"#TITANCORE_BARRAGE_DESC"
+	"longdesc"										"#TITANCORE_BARRAGE_LONGDESC"
 
 	"menu_icon"										"brute/menu/barrage_core"
 	"hud_icon"										"brute/menu/barrage_core"
@@ -36,8 +36,8 @@ WeaponData
 	"core_duration"									"5.5"
 	"passive"										"PAS_FUSION_CORE"
 
-	"readymessage"									"BARRAGE CORE ONLINE"
-	"readyhint"									"`1%ability 1% `0Activate Barrage Core"
+	"readymessage"									"#HUD_CORE_ONLINE_BARRAGE_CORE"
+	"readyhint"									"#HUD_CORE_ONLINE_BARRAGE_CORE_HINT"
 
 	"dialog_core_online"							"flightCoreOnline"
 	"dialog_core_activated"							"flightCoreActivated"


### PR DESCRIPTION
- Fixes barrage core's ``printname``, ``readymessage`` and ``readyhint`` not being localized.
- Fixes barrage core's ``shortprintname`` and descriptions using the wrong strings.
- Fixes cluster payload not having a ``sound_weapon_ready`` sound.

Before:
https://github.com/user-attachments/assets/8af85733-a07a-49b8-8195-9557d09b9f8b

After:
https://github.com/user-attachments/assets/d51eec56-4d3b-4390-b539-b24026cd0874

- Can no longer use cluster payload while having max ammo, as it ocasionally caused issues.

Before:
https://github.com/user-attachments/assets/c5d4607b-f150-4b8d-a8b3-f8dff2dc8b33

After:
https://github.com/user-attachments/assets/eeeb8aba-b26c-4a01-b68f-dae5c1392c75



