### PR TITLE
Use unique Quad Rocket crosshair

### DIFF
--- a/mods/Dinorush.Brute4/mod/scripts/weapons/mp_titanweapon_brute4_quad_rocket.txt
+++ b/mods/Dinorush.Brute4/mod/scripts/weapons/mp_titanweapon_brute4_quad_rocket.txt
@@ -483,7 +483,7 @@ WeaponData
 
 		Crosshair_1
 		{
-			"ui"						"ui/crosshair_smr"
+			"ui"						"ui/crosshair_quad_rocket"
 			"base_spread"				"10.0"
 			Args
 			{


### PR DESCRIPTION
Respawn made a unique crosshair for the Quad Rocket, and then didn't use it for some reason. This pr just makes Brute's quad rocket actually use it

Before:
![1237970_20241110205603_1](https://github.com/user-attachments/assets/8c4051de-391e-402d-a21b-13aec543314b)
![1237970_20241110210237_1](https://github.com/user-attachments/assets/29e0cba4-78e3-4e95-bfba-4d5fba8e7302)

After:
![1237970_20241110205630_1](https://github.com/user-attachments/assets/3ee8d3fa-0baa-4920-b3fd-de5856445e15)
![1237970_20241110205634_1](https://github.com/user-attachments/assets/4ab65e40-82c7-4867-bef1-940d2b9ca0d6)
